### PR TITLE
Update requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "pandas>=1.5.3",
     "scikit-learn>=1.2.2",
     "scipy>=1.10.1",
-    "sklearn>=0.0.post1",
     "spacy>=3.5.1",
     "spacy-legacy>=3.0.12",
     "spacy-loggers>=1.0.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,6 @@ sacremoses==0.0.35
 scikit-learn==1.2.2
 scipy==1.10.1
 six==1.16.0
-sklearn==0.0.post1
 smart-open==6.3.0
 soupsieve==2.4
 spacy==3.5.1


### PR DESCRIPTION
sklearn can be removed from `requirements.txt` since it's deprecated and `scikit-learn` is also included in `requirements.txt`

xref: https://pypi.org/project/sklearn/